### PR TITLE
Add download and restore capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # backwork [![Build Status](https://travis-ci.org/IBM/backwork.svg?branch=master)](https://travis-ci.org/IBM/backwork) [![PyPI version](https://badge.fury.io/py/backwork.svg)](https://badge.fury.io/py/backwork)
 Backup simplified.
 
-`backwork` is a toolkit that simplifies the process of backing up databases. It
-handles the backup process itself as well as upload and error notification.
+`backwork` is a toolkit that simplifies the process of backing up and restoring databases. It
+handles the backup process itself as well as upload, download, restoration, and error notification.
 
 ## Prerequisites
 * Python 2.7
@@ -17,10 +17,10 @@ $ pip install backwork
 After installing you should have a `backwork` command available.
 ```
 $ backwork --help
-usage: backwork [-h] [-n NOTIFIERS] {backup,upload} ...
+usage: backwork [-h] [-n NOTIFIERS] {backup,restore,upload,download} ...
 
 positional arguments:
-  {backup,upload}
+  {backup,restore,upload,download}
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -38,11 +38,10 @@ $ pip install <plug-in_name>
 Plug-ins are divided into three categories:
 
 ### Backup
-Backup plug-ins are responsible for connecting to a databases and doing the
-actual backup process.
+Backup plug-ins are responsible for connecting to databases and doing the
+actual backup process, as well as the restore process for the backups.
 
-Once you install a backup plug-in it will be available via the `backwork backup`
-command:
+Once you install a backup plug-in it will be available via the `backwork backup` and `backwork restore` commands:
 ```sh
 $ backwork backup --help
 usage: backwork backup [-h] [-U] {mongo} ...
@@ -59,13 +58,27 @@ optional arguments:
                 command
 ```
 
+```
+usage: backwork restore [-h] [-U] {mongo} ...
+
+Perform database restores. Run `backwork restore {database_type} -h` for more
+details on each supported database.
+
+positional arguments:
+  {mongo}
+
+optional arguments:
+  -h, --help    show this help message and exit
+```
+
+
 #### Available plug-ins:
 * `backwork-backup-mongo`
 
 ### Upload
-Upload plug-ins store your backup files securely in a remote storage.
+Upload plug-ins store and retrieve your backup files securely from remote storage.
 
-You can use them with the `backwork upload` command:
+You can use them with the `backwork upload` and `backwork download` commands:
 ```sh
 $ backwork upload --help
 usage: backwork upload [-h] {softlayer} ...
@@ -79,6 +92,21 @@ positional arguments:
 optional arguments:
   -h, --help   show this help message and exit
 ```
+
+```sh
+$ backwork download --help
+usage: backwork download [-h] {softlayer} ...
+
+Download a file from a remote service. Run `backwork upload {service} -h` for more
+details on each supported service.
+
+positional arguments:
+  {softlayer}
+
+optional arguments:
+  -h, --help   show this help message and exit
+```
+
 #### Available plug-ins:
 * `backwork-upload-softlayer`
 
@@ -279,6 +307,9 @@ setup(
     entry_points={
         "backwork.backups": [
             "<COMMAND NAME>": "module:BackupClass"
+        ],
+        "backwork.restores": [
+            "<COMMAND NAME>": "module:RestoreClass"
         ]
     },
     ...
@@ -291,6 +322,9 @@ setup(
     entry_points={
         "backwork.uploads": [
             "<COMMAND NAME>": "module:UploadClass"
+        ],
+        "backwork.downloads": [
+            "<COMMAND NAME>": "module:DownloadClass"
         ]
     },
     ...

--- a/backwork/backwork.py
+++ b/backwork/backwork.py
@@ -10,6 +10,7 @@ import logging
 import sys
 
 from . import backup
+from . import restore
 from . import notifiers
 from . import upload
 from . import download
@@ -30,6 +31,7 @@ def parse_args():
     # parse subcommand
     subparsers = parser.add_subparsers(dest="command")
     backup.parse_args(subparsers)
+    restore.parse_args(subparsers)
     upload.parse_args(subparsers)
     download.parse_args(subparsers)
 
@@ -44,6 +46,9 @@ def main():
     try:
         if args.command == "backup":
             backup.backup(args, extra)
+
+        elif args.command == "restore":
+            restore.restore(args, extra)
 
         elif args.command == "upload":
             upload.upload(args, extra)

--- a/backwork/backwork.py
+++ b/backwork/backwork.py
@@ -12,6 +12,8 @@ import sys
 from . import backup
 from . import notifiers
 from . import upload
+from . import download
+
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO,
                     format="%(asctime)s %(name)s %(levelname)-7s %(message)s")
@@ -30,6 +32,7 @@ def parse_args():
     subparsers = parser.add_subparsers(dest="command")
     backup.parse_args(subparsers)
     upload.parse_args(subparsers)
+    download.parse_args(subparsers)
 
     return parser.parse_known_args()
 
@@ -45,6 +48,9 @@ def main():
 
         elif args.command == "upload":
             upload.upload(args, extra)
+
+        elif args.command == "download":
+            download.download(args, extra)
 
     except Exception as error:  # pylint: disable=broad-except
         notifiers.notify(error)

--- a/backwork/backwork.py
+++ b/backwork/backwork.py
@@ -14,7 +14,6 @@ from . import notifiers
 from . import upload
 from . import download
 
-
 logging.basicConfig(stream=sys.stdout, level=logging.INFO,
                     format="%(asctime)s %(name)s %(levelname)-7s %(message)s")
 

--- a/backwork/download.py
+++ b/backwork/download.py
@@ -1,0 +1,39 @@
+"""Handle download subcommand.
+
+Download commands take a file from a remote service and download them to the local filesystem. They
+should raise exceptions in case of failures so that notifiers can handle them.
+"""
+import os
+from .lib import utils
+
+__all__ = ["parse_args", "download", "DownloadError"]
+
+CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
+ENGINES = utils.load_engines("backwork.downloads")
+
+
+def parse_args(subparsers):
+    """Add parsing rules for the download command and subcommands."""
+    description = """Download a file from remote service. Run `backwork download
+        {service} -h` for more details on each supported service."""
+    download_parser = subparsers.add_parser(
+        "download", description=description)
+    download_subparsers = download_parser.add_subparsers(dest="service")
+
+    for _, klass in ENGINES.items():
+        klass.parse_args(download_subparsers)
+
+
+def download(args, extra):
+    """Route download command to the selected download handler."""
+    engine = ENGINES.get(args.service, None)
+
+    if engine is None:
+        raise DownloadError("Download method '%s' not found.", args.service)
+
+    engine(args, extra).download()
+
+
+class DownloadError(Exception):
+    """Backwork Download Error"""
+    pass

--- a/backwork/restore.py
+++ b/backwork/restore.py
@@ -1,0 +1,46 @@
+"""Handle restore subcommand.
+
+Restore commands should receive an argument specifying where to look for the
+file to restore from.
+"""
+
+import os
+from .lib import utils
+
+__all__ = ["parse_args", "restore", "RestoreError"]
+
+CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
+ENGINES = utils.load_engines("backwork.restores")
+
+
+def parse_args(subparsers):
+    """Parse command line arguments passed to the restore command."""
+    restore_parser = subparsers.add_parser("restore",
+                                           description="""Perform database
+                                        restores. Run `backwork restore
+                                        {database_type} -h` for more details
+                                        on each supported database.""")
+
+    restore_parser.add_argument("-U", "--upload", action="store_true",
+                                help="""output restore data to stdout to allow
+                               piping it to an upload command""")
+
+    # load engines' parsers
+    restore_subparsers = restore_parser.add_subparsers(dest="type")
+    for _, klass in ENGINES.items():
+        klass.parse_args(restore_subparsers)
+
+
+def restore(args, extra):
+    """Invoke the restore method from the specified database type."""
+    engine = ENGINES.get(args.type, None)
+
+    if engine is None:
+        raise RestoreError("Restore method '%s' not found.", args.type)
+
+    engine(args, extra).restore()
+
+
+class RestoreError(Exception):
+    """Custom Exception raised by restore engines."""
+    pass

--- a/backwork/restore.py
+++ b/backwork/restore.py
@@ -21,10 +21,6 @@ def parse_args(subparsers):
                                         {database_type} -h` for more details
                                         on each supported database.""")
 
-    restore_parser.add_argument("-U", "--upload", action="store_true",
-                                help="""output restore data to stdout to allow
-                               piping it to an upload command""")
-
     # load engines' parsers
     restore_subparsers = restore_parser.add_subparsers(dest="type")
     for _, klass in ENGINES.items():


### PR DESCRIPTION
This PR enables:
- upload plug-ins to have download support
- backup plug-ins to have restore support

which ultimately makes backwork a more full-featured and powerful backup tool.

I think the decision to have a single `upload` plug-in handle both upload and download, and a single `backup` plug-in handle backup and restore, makes sense from an information hiding perspective. The downside is arguably the naming convention is a bit confusing at the moment.