### PR TITLE
add show subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ optional arguments:
 ### Upload
 Upload plug-ins store and retrieve your backup files securely from remote storage.
 
-You can use them with the `backwork upload` and `backwork download` commands:
+You can use them with the `backwork upload`, `backwork show`, and `backwork download` commands:
 ```sh
 $ backwork upload --help
 usage: backwork upload [-h] {softlayer} ...
@@ -91,6 +91,20 @@ positional arguments:
 
 optional arguments:
   -h, --help   show this help message and exit
+```
+
+```sh
+$ backwork show --help
+usage: backwork show [-h] {cos} ...
+
+Shows available backups on a remote service. Run `backwork show {service} -h` for
+more details on each supported service.
+
+positional arguments:
+  {cos}
+
+optional arguments:
+  -h, --help  show this help message and exit
 ```
 
 ```sh
@@ -323,6 +337,9 @@ setup(
         "backwork.uploads": [
             "<COMMAND NAME>": "module:UploadClass"
         ],
+        "backwork.shows": [
+            "<COMMAND NAME>": "module:ShowClass"
+        ]
         "backwork.downloads": [
             "<COMMAND NAME>": "module:DownloadClass"
         ]

--- a/backwork/backwork.py
+++ b/backwork/backwork.py
@@ -13,6 +13,7 @@ from . import backup
 from . import restore
 from . import notifiers
 from . import upload
+from . import show
 from . import download
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO,
@@ -33,6 +34,7 @@ def parse_args():
     backup.parse_args(subparsers)
     restore.parse_args(subparsers)
     upload.parse_args(subparsers)
+    show.parse_args(subparsers)
     download.parse_args(subparsers)
 
     return parser.parse_known_args()
@@ -52,6 +54,9 @@ def main():
 
         elif args.command == "upload":
             upload.upload(args, extra)
+
+        elif args.command == "show":
+            show.show(args, extra)
 
         elif args.command == "download":
             download.download(args, extra)

--- a/backwork/show.py
+++ b/backwork/show.py
@@ -1,0 +1,40 @@
+"""Handle show subcommand.
+
+Show commands take a path or prefix in a remote service and return a list of files that exist
+in that location. They are intented to help with the use of the show subcommand.
+They should raise exceptions in case of failures so that notifiers can handle them.
+"""
+import os
+from .lib import utils
+
+__all__ = ["parse_args", "show", "ShowError"]
+
+CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
+ENGINES = utils.load_engines("backwork.shows")
+
+
+def parse_args(subparsers):
+    """Add parsing rules for the show command and subcommands."""
+    description = """Shows available backups on a remote service. Run `backwork show
+        {service} -h` for more details on each supported service."""
+    show_parser = subparsers.add_parser(
+        "show", description=description)
+    show_subparsers = show_parser.add_subparsers(dest="service")
+
+    for _, klass in ENGINES.items():
+        klass.parse_args(show_subparsers)
+
+
+def show(args, extra):
+    """Route show command to the selected show handler."""
+    engine = ENGINES.get(args.service, None)
+
+    if engine is None:
+        raise ShowError("Show method '%s' not found.", args.service)
+
+    engine(args, extra).show()
+
+
+class ShowError(Exception):
+    """Backwork Show Error"""
+    pass


### PR DESCRIPTION
Adds a `show` subcommand to upload modules. It's useful to be able to list the existing backups before using the `download` command.